### PR TITLE
Add submodule setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Basically, Daikin have gone all cloudy with the latest WiFi controllers. This mo
 
 Git clone this `--recursive` to get all the submodules, and it should build with just `make`. There are make targets for other variations, but this hardware is the `make pico` or `make s3` version. The `make` actually runs the normal `idf.py` to build which then uses cmake. `make menuconfig` can be used to fine tune the settings, but the defaults should be mostly sane. `make flash` should work to program. If flashing yourself, you will need a programming lead, e.g. [Tazmotizer](https://github.com/revk/Shelly-Tasmotizer-PCB) or similar, and of course the full ESP IDF environment. The latest boards also have 4 pads for direct USB connection to flash with no adaptor. The modules on Amazon come pre-loaded and can upgrade over the air.
 
+If you forget to clone with `--recursive`, run `python setup_submodules.py` (or
+`setup_submodules.bat` on Windows) in the repository root to fetch all the
+required libraries.
+
 The code is normally set up to automatically upgrade the software, checking roughtly once a week. You can change this in settings via MQTT.
 
 If you build yourself, you either need no code signing, or your own signing key. This will break auto-updates which try to load my code releases, so you need to adjuist settings `otahost` and `otaauto` accordingly. You can set these in the build config, along with WiFi settings, etc.

--- a/setup_submodules.bat
+++ b/setup_submodules.bat
@@ -1,0 +1,12 @@
+@echo off
+REM Fetch all submodules recursively
+if not defined GIT (
+  where git >nul 2>nul || (
+    echo Git not found. Please install Git and retry.
+    goto end
+  )
+)
+
+git submodule update --init --recursive
+
+:end

--- a/setup_submodules.py
+++ b/setup_submodules.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Utility to initialise and update all git submodules."""
+import subprocess
+import os
+import sys
+
+def main() -> None:
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(repo_root)
+    cmd = ["git", "submodule", "update", "--init", "--recursive"]
+    print("Running:", " ".join(cmd))
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed: {exc}", file=sys.stderr)
+        sys.exit(exc.returncode)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `setup_submodules.py` helper
- add a Windows `setup_submodules.bat`
- document the new helper scripts in README

## Testing
- `python3 -m py_compile setup_submodules.py`


------
https://chatgpt.com/codex/tasks/task_e_6865b3c598f48330905f593110434c9b