### PR TITLE
Extend API stubs and board support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,5 +14,7 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - Remote method endpoints implemented.
 - Stub handlers for additional HTTP API endpoints in place.
 - ESP32-S2 build target available.
+- ESP32-S3 build target available.
+- Target temperature and LED state persist across HTTP calls.
 
 For questions or larger design changes, open a GitHub issue first.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -173,6 +173,8 @@ static httpd_handle_t webserver = NULL;
 static uint8_t proto = 0;
 static char remote_method[16] = "home only";
 static uint8_t notify_enabled = 0;
+static float stub_target = 20.0;
+static uint8_t led_state = 1;
 
 static int
 uart_enabled (void)
@@ -2637,7 +2639,8 @@ legacy_web_set_price (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_target (httpd_req_t * req)
 {
-   jo_t j = legacy_ok ();
+   jo_t j = legacy_ok ();          // Report stored stub value
+   jo_litf (&j, "target", "%.1f", stub_target);
    return legacy_send (req, &j);
 }
 
@@ -2649,7 +2652,18 @@ legacy_web_set_target (httpd_req_t * req)
    if (!j)
       err = "Query failed";
    else
+   {
+      if (jo_find (j, "target") || jo_find (j, "stemp"))
+      {
+         char *v = jo_strdup (j);
+         if (v)
+         {
+            stub_target = atof (v);
+            free (v);
+         }
+      }
       jo_free (&j);
+   }
    return legacy_simple_response (req, err);
 }
 
@@ -2786,7 +2800,18 @@ legacy_web_set_led (httpd_req_t * req)
    if (!j)
       err = "Query failed";
    else
+   {
+      if (jo_find (j, "led"))
+      {
+         char *v = jo_strdup (j);
+         if (v)
+         {
+            led_state = atoi (v) ? 1 : 0;
+            free (v);
+         }
+      }
       jo_free (&j);
+   }
    return legacy_simple_response (req, err);
 }
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Basically, Daikin have gone all cloudy with the latest WiFi controllers. This mo
 * or, works with BlueCoinT and Telink [BLE temperature sensor](Manuals/BLE.md) as a remote reference in an auto mode
 * Automatically works out if S21 or X50 protocol (used on bigger/ducted units)
 * Backwards compatible direct `/aircon/...` URLs
+* Stub HTTP endpoints remember target temperature and LED settings
 
 # Building code yourself
 

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -75,3 +75,4 @@ messages so that Faikin mirrors the official modules.
   report the current access policy.
 - [x] Added stub handlers for remaining HTTP endpoints so third-party clients
   receive `ret=OK` responses.
+- [x] Target temperature and LED settings are remembered between requests.


### PR DESCRIPTION
## Summary
- store target temperature and LED value so repeated API calls reflect last values
- note persisting stubs in README and progress docs
- document ESP32-S3 build target is available

## Testing
- `make -C ESP` *(fails: /bin/csh missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf00541c83309f69174040dcb25d