### PR TITLE
Implement stub power history endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - ESP32-S2 build target available.
 - Notification, region and LED endpoints persist settings.
 - Timer and program endpoints remember the last supplied parameters.
+- Power history endpoints provide placeholder values for compatibility.
 - ESP32-S3 build target available.
 
 For questions or larger design changes, open a GitHub issue first.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2532,22 +2532,38 @@ legacy_web_register_terminal (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_year_power (httpd_req_t * req)
 {
+   /*
+    * The official Daikin modules report monthly usage for the current and
+    * previous year.  We do not yet track per-month totals so return the
+    * current accumulated Wh value in the first month and zeroes elsewhere.
+    */
    jo_t j = legacy_ok ();
-   jo_stringf (j, "curr_year_heat", "%u/0/0/0/0/0/0/0/0/0/0/0", daikin.Wh / 100);       // Bodge, does not resent each year yet
-   jo_string (j, "prev_year_heat", "0/0/0/0/0/0/0/0/0/0/0/0");
-   jo_string (j, "curr_year_cool", "0/0/0/0/0/0/0/0/0/0/0/0");
-   jo_string (j, "prevyear_cool", "0/0/0/0/0/0/0/0/0/0/0/0");
+   jo_stringf (j, "curr_year_heat",
+               "%u/0/0/0/0/0/0/0/0/0/0/0",
+               daikin.Wh / 100);
+   jo_string (j, "prev_year_heat",
+              "0/0/0/0/0/0/0/0/0/0/0/0");
+   jo_string (j, "curr_year_cool",
+              "0/0/0/0/0/0/0/0/0/0/0/0");
+   jo_string (j, "prevyear_cool",
+              "0/0/0/0/0/0/0/0/0/0/0/0");
    return legacy_send (req, &j);
 }
 
 static esp_err_t
 legacy_web_get_week_power (httpd_req_t * req)
 {
-   // ret=OK,s_dayw=2,week_heat=0/0/0/0/0/0/0/0/0/0/0/0/0/0,week_cool=0/0/0/0/0/0/0/0/0/0/0/0/0/0
-   // Have no idea how to implement it, perhaps the original module keeps some internal statistics.
-   // For now let's just prevent errors in OpenHAB and return an empty OK response
-   // Note all zeroes from my BRP
+   /*
+    * The real controller returns power usage for the last two weeks.  Until we
+    * have proper statistics just return placeholder zero values so that client
+    * applications do not error.
+    */
    jo_t j = legacy_ok ();
+   jo_string (j, "s_dayw", "0");
+   jo_string (j, "week_heat",
+              "0/0/0/0/0/0/0/0/0/0/0/0/0/0");
+   jo_string (j, "week_cool",
+              "0/0/0/0/0/0/0/0/0/0/0/0/0/0");
    return legacy_send (req, &j);
 }
 

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -86,3 +86,5 @@ messages so that Faikin mirrors the official modules.
 - [x] `/aircon/get_timer`, `/aircon/set_timer`, `/aircon/get_program`,
   `/aircon/set_program` and `/aircon/get_scdltimer`/`set_scdltimer`
   preserve the most recently supplied values.
+- [x] `/aircon/get_year_power` and `/aircon/get_week_power` now return
+  placeholder statistics so clients receive expected fields.


### PR DESCRIPTION
## Summary
- emulate Daikin power history replies
- document new API progress

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865c60bf0248330b41bb516736e8c94