### PR TITLE
Persist holiday endpoint settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,6 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - ESP32-S3 build target available.
 - Timer, program and schedule timer settings now stored persistently.
 - Target, price and remote method updates apply immediately and are saved.
+- Holiday endpoint settings stored for later retrieval.
 
 For questions or larger design changes, open a GitHub issue first.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -182,6 +182,7 @@ static uint8_t led_state = 1;         // Stored LED setting for legacy API
 static char timer_state[96] = "";     // Stored /set_timer parameters
 static char program_state[96] = "";   // Stored /set_program parameters
 static char scdl_timer_state[96] = "";// Stored /set_scdltimer parameters
+static char holiday_state[96] = "";   // Stored /set_holiday parameters
 
 // Energy history for the last two weeks (14 entries of daily usage)
 static uint8_t power_week_index = 0;
@@ -2272,7 +2273,15 @@ legacy_web_set_holiday (httpd_req_t * req)
       err = "Query failed";
    else
    {
-      // TODO - ignore for now
+      size_t len = httpd_req_get_url_query_len (req);
+      if (len >= sizeof (holiday_state))
+         len = sizeof (holiday_state) - 1;
+      if (httpd_req_get_url_query_str (req, holiday_state, len + 1) != ESP_OK)
+         holiday_state[0] = 0;
+      jo_t s = jo_object_alloc();
+      jo_string (s, "holiday", holiday_state);
+      revk_settings_store (s, NULL, 1);
+      jo_free (&s);
       jo_free (&j);
    }
    return legacy_simple_response (req, err);

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -88,3 +88,4 @@ messages so that Faikin mirrors the official modules.
   preserve the most recently supplied values.
 - [x] `/aircon/get_year_power` and `/aircon/get_week_power` now return
   placeholder statistics so clients receive expected fields.
+- [x] `/aircon/set_holiday` persists the provided parameters for later queries.


### PR DESCRIPTION
## Summary
- preserve parameters supplied to `/aircon/set_holiday`
- document new behaviour in integration plan and progress notes

## Testing
- `make s3` *(fails: components/ESP32-RevK/buildsuffix: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68663cf88340833099c8b90af3aa524a