### PR TITLE
Persist special mode and demand API settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,6 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - Timer, program and schedule timer settings now stored persistently.
 - Target, price and remote method updates apply immediately and are saved.
 - Holiday endpoint settings stored for later retrieval.
+- Special mode and demand control settings persisted via HTTP API.
 
 For questions or larger design changes, open a GitHub issue first.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2312,7 +2312,15 @@ legacy_web_set_demand_control (httpd_req_t * req)
             demand = atoi (v);
          free (v);
       }
-      daikin_set_i_e (err, demand, on ? demand : 100);
+      int new_demand = on ? demand : 100;
+      daikin_set_i_e (err, demand, new_demand);
+      if (!err)
+      {
+         jo_t s = jo_object_alloc();
+         jo_int (s, "demand", new_demand);
+         revk_settings_store (s, NULL, 1);
+         jo_free (&s);
+      }
       jo_free (&j);
    }
    return legacy_simple_response (req, err);
@@ -2645,12 +2653,33 @@ legacy_web_set_special_mode (httpd_req_t * req)
       {
       case 1:                  // powerful
          err = daikin_set_v (powerful, mode);
+         if (!err)
+         {
+            jo_t s = jo_object_alloc();
+            jo_bool (s, "powerful", mode);
+            revk_settings_store (s, NULL, 1);
+            jo_free (&s);
+         }
          break;
       case 2:                  // eco
          err = daikin_set_v (econo, mode);
+         if (!err)
+         {
+            jo_t s = jo_object_alloc();
+            jo_bool (s, "econo", mode);
+            revk_settings_store (s, NULL, 1);
+            jo_free (&s);
+         }
          break;
       case 3:                  // streamer
          err = daikin_set_v (streamer, mode);
+         if (!err)
+         {
+            jo_t s = jo_object_alloc();
+            jo_bool (s, "streamer", mode);
+            revk_settings_store (s, NULL, 1);
+            jo_free (&s);
+         }
          break;
       default:
          err = "Unknown kind";

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -89,3 +89,5 @@ messages so that Faikin mirrors the official modules.
 - [x] `/aircon/get_year_power` and `/aircon/get_week_power` now return
   placeholder statistics so clients receive expected fields.
 - [x] `/aircon/set_holiday` persists the provided parameters for later queries.
+- [x] `/aircon/set_special_mode` and `/aircon/set_demand_control` now
+  store the selected settings for later retrieval.


### PR DESCRIPTION
## Summary
- persist `/aircon/set_special_mode` selections
- persist demand control limit in `/aircon/set_demand_control`
- document new behaviour in AGENTS and integration plan

## Testing
- `make -C Tools` *(fails: `/bin/csh` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68663e5a8ea4833089d72ef8015a0aa8