### PR TITLE
Update integration plan with API note

### DIFF
--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -27,6 +27,12 @@ To improve compatibility we added stub handlers for the missing endpoints.  They
 
 These stubs provide a foundation for future development.  Implementing full behaviour will require referencing hardware capabilities and extending the control logic in `Faikin.c`.
 
+**Important:** Only implement endpoints that are known from the official Daikin
+modules.  The list above mirrors the API documented at
+[daikin-control](https://github.com/Amtho/daikin-control).  Avoid adding new
+URLs until they are verified to exist on the real hardware so that third party
+clients remain compatible.
+
 ## Task breakdown
 
 The [S21 protocol documentation](../Manuals/S21.md) describes how values are


### PR DESCRIPTION
## Summary
- emphasize that only known official HTTP endpoints should be implemented

## Testing
- `make s2` *(fails: components/ESP32-RevK/buildsuffix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686645ae74f88330a202f04ee7b1cb1e