### PR TITLE
Document remaining stub endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,4 +22,24 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - Timer, program and schedule timer settings now stored persistently.
 - Target, price and remote method updates apply immediately and are saved.
 
+## Pending hardware implementation
+
+The following HTTP API endpoints have basic stub handlers. They store values
+for compatibility but do not yet interact with the air-con hardware.  Future
+work should update these handlers to translate incoming parameters into the
+appropriate S21 or CN_WIRED commands so Faikin mirrors the official Daikin
+modules.
+
+- `/aircon/get_timer` and `/aircon/set_timer`
+- `/aircon/get_program` and `/aircon/set_program`
+- `/aircon/get_scdltimer` and `/aircon/set_scdltimer`
+- `/aircon/get_price` and `/aircon/set_price`
+- `/common/get_notify` and `/common/set_notify`
+- `/common/get_remote_method` and `/common/set_remote_method`
+- `/common/set_regioncode`
+- `/aircon/get_year_power` and `/aircon/get_week_power`
+
+Implementing these will require referencing the Daikin protocol documents in
+`Manuals/S21.md` and extending the control logic in `ESP/main/Faikin.c`.
+
 For questions or larger design changes, open a GitHub issue first.


### PR DESCRIPTION
## Summary
- note stubbed HTTP endpoints for later hardware integration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68664cec3f248330877789198ed780e3