### PR TITLE
Support numeric remote method values

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2792,8 +2792,13 @@ legacy_web_set_remote_method (httpd_req_t * req)
          char *v = jo_strdup (j);
          if (v)
          {
-            strncpy (remote_method, v, sizeof (remote_method) - 1);
-            remote_method[sizeof (remote_method) - 1] = 0;
+            if (!strcmp(v, "1") || !strcasecmp(v, "anywhere"))
+               strncpy(remote_method, "anywhere", sizeof(remote_method)-1);
+            else if (!strcmp(v, "0") || !strcasecmp(v, "home only") || !strcasecmp(v, "home"))
+               strncpy(remote_method, "home only", sizeof(remote_method)-1);
+            else
+               strncpy(remote_method, v, sizeof(remote_method)-1);
+            remote_method[sizeof(remote_method) - 1] = 0;
             jo_t s = jo_object_alloc();
             jo_string (s, "remote_method", remote_method);
             revk_settings_store (s, NULL, 1);

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -79,6 +79,8 @@ messages so that Faikin mirrors the official modules.
 
 - [x] `/common/get_remote_method` and `/common/set_remote_method` store and
   report the current access policy.
+- [x] `/common/set_remote_method` accepts numeric values (`0` or `1`) for
+  compatibility with some clients.
 - [x] Added stub handlers for remaining HTTP endpoints so third-party clients
   receive `ret=OK` responses.
 - [x] `/aircon/get_target` and `/aircon/set_target` persist the requested


### PR DESCRIPTION
## Summary
- support numeric `method` values for `/common/set_remote_method`
- note this compatibility in the integration plan

## Testing
- `make -C Tools` *(fails: Please install /bin/csh or equivalent)*

------
https://chatgpt.com/codex/tasks/task_e_68664f34d2888330a33682a98269e475