### PR TITLE
Improve timer API responses

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2573,7 +2573,7 @@ legacy_web_get_timer (httpd_req_t * req)
 {
    jo_t j = legacy_ok ();          // No timer functionality yet
    if (*timer_state)
-      jo_string (j, "state", timer_state);
+      jo_string (j, "timer", timer_state);
    return legacy_send (req, &j);
 }
 
@@ -2676,7 +2676,7 @@ legacy_web_get_program (httpd_req_t * req)
 {
    jo_t j = legacy_ok ();
    if (*program_state)
-      jo_string (j, "state", program_state);
+      jo_string (j, "program", program_state);
    return legacy_send (req, &j);
 }
 
@@ -2708,7 +2708,7 @@ legacy_web_get_scdltimer (httpd_req_t * req)
 {
    jo_t j = legacy_ok ();
    if (*scdl_timer_state)
-      jo_string (j, "state", scdl_timer_state);
+      jo_string (j, "scdltimer", scdl_timer_state);
    return legacy_send (req, &j);
 }
 

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -94,6 +94,9 @@ messages so that Faikin mirrors the official modules.
 - [x] `/aircon/get_timer`, `/aircon/set_timer`, `/aircon/get_program`,
   `/aircon/set_program` and `/aircon/get_scdltimer`/`set_scdltimer`
   preserve the most recently supplied values.
+- [x] Timer, program and scdl timer queries now report the stored
+  parameters using their original field names so third-party clients see
+  `timer=`, `program=` and `scdltimer=` responses.
 - [x] `/aircon/get_year_power` and `/aircon/get_week_power` now return
   placeholder statistics so clients receive expected fields.
 - [x] `/common/set_led` now updates the LED state via S21 commands when


### PR DESCRIPTION
## Summary
- refine `/aircon/get_timer`, `/aircon/get_program` and `/aircon/get_scdltimer` so responses use official parameter names
- document new behaviour in integration plan

## Testing
- `make -C ESP -n` *(fails: components/ESP32-RevK/buildsuffix missing)*

------
https://chatgpt.com/codex/tasks/task_e_686654554a6483308c306e5d527ca1b8