### PR TITLE
Persist power history once per day

### DIFF
--- a/ESP/main/settings.def
+++ b/ESP/main/settings.def
@@ -85,6 +85,11 @@ s	auto.b				.live					// BLE sensor ID
 #endif
 
 u32     power.week      0                 .live   .array=14          / Daily power usage history (Wh)
+u32     power.month     0                 .live   .array=12          / Monthly power usage history (Wh)
+u8      power.weekindex 0                 .hide                    / Current week index
+u16     power.day       0                 .hide                    / Last recorded day
+u8      power.monthidx  0                 .hide                    / Last recorded month
+u32     power.wh        0                 .hide                    / Last Wh reading
 
 bit	auto.e		1		.live					// Enable auto time and power operations
 u16	auto.0				.live					// HHMM format turn off time


### PR DESCRIPTION
## Summary
- store daily and monthly power readings in NVS
- save power history only once per day
- restore power history on boot

## Testing
- `make -C ESP main/settings.h` *(fails: Please install /bin/csh or equivalent)*

------
https://chatgpt.com/codex/tasks/task_e_6866572074248330b3c8b2b8b851d9b3