### PR TITLE
Fix field name in power stats

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2623,7 +2623,7 @@ legacy_web_get_year_power (httpd_req_t * req)
               "0/0/0/0/0/0/0/0/0/0/0/0");
    jo_string (j, "curr_year_cool",
               "0/0/0/0/0/0/0/0/0/0/0/0");
-   jo_string (j, "prevyear_cool",
+   jo_string (j, "prev_year_cool",
               "0/0/0/0/0/0/0/0/0/0/0/0");
    return legacy_send (req, &j);
 }

--- a/Tools/integration_plan.md
+++ b/Tools/integration_plan.md
@@ -103,3 +103,5 @@ messages so that Faikin mirrors the official modules.
   hardware is connected.
 - [x] ESP32-S2 and ESP32-S3 build targets are available and select default
   UART pins for those boards.
+- [x] Fixed `/aircon/get_year_power` to return the `prev_year_cool` field
+  using the correct name so clients match the official API.


### PR DESCRIPTION
## Summary
- match Daikin API field name `prev_year_cool`
- document the fix in integration plan progress

## Testing
- `make -n` *(fails: components/ESP32-RevK/buildsuffix not found)*

------
https://chatgpt.com/codex/tasks/task_e_686659e4c49883308eb4300b8c5d17e8