### PR TITLE
Update tasks and improve boolean handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,23 +5,10 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 
 ## Current Tasks
 
-- Extend the HTTP API according to `Tools/integration_plan.md`. Ensure stub
-  endpoints behave like the official modules while integration work continues.
-- Add build and configuration support for **ESP32‑S2** and **ESP32‑S3** boards.
+The main outstanding work is implementing hardware support for the stubbed
+HTTP API endpoints.  See the list below.
 
-## Progress
-
-- Remote method endpoints implemented.
-- Stub handlers for additional HTTP API endpoints in place.
-- Target and price endpoints persist values for later retrieval.
-- ESP32-S2 build target available.
-- Default UART pins configured for ESP32-S2 boards.
-- Notification, region and LED endpoints persist settings.
-- Timer and program endpoints remember the last supplied parameters.
-- Power history endpoints provide placeholder values for compatibility.
-- ESP32-S3 build target available.
-- Timer, program and schedule timer settings now stored persistently.
-- Target, price and remote method updates apply immediately and are saved.
+For details of previously completed tasks see **DONE.md**.
 
 ## Pending hardware implementation
 

--- a/DONE.md
+++ b/DONE.md
@@ -1,0 +1,11 @@
+# Completed Tasks
+
+The following tasks from `AGENTS.md` have been finished:
+
+- Extended the HTTP API with stub endpoints matching the official modules.
+- Added build and configuration support for **ESP32‑S2** and **ESP32‑S3** boards, including default UART pin mappings.
+- Target, price and remote method updates are stored persistently and apply immediately.
+- Timer, program and schedule timer values are saved across reboots.
+- Power history endpoints return placeholder data for compatibility.
+- Notification, region and LED settings persist and `/common/set_led` now supports "on"/"off" values.
+

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -183,6 +183,15 @@ static char timer_state[96] = "";     // Stored /set_timer parameters
 static char program_state[96] = "";   // Stored /set_program parameters
 static char scdl_timer_state[96] = "";// Stored /set_scdltimer parameters
 
+static int
+parse_bool (const char *v)
+{
+   if (!v)
+      return 0;
+   return (!strcasecmp (v, "1") || !strcasecmp (v, "true") ||
+           !strcasecmp (v, "on")) ? 1 : 0;
+}
+
 // Energy history for the last two weeks (14 entries of daily usage)
 static uint32_t powerweek[14] = {0};
 static uint32_t powermonth[12] = {0};
@@ -324,7 +333,7 @@ load_legacy_settings(void)
    if ((s = revk_settings_find("notify", NULL)) &&
        (v = revk_settings_text(s, 0, NULL)))
    {
-      notify_enabled = atoi(v) ? 1 : 0;
+      notify_enabled = parse_bool(v);
       free(v);
    }
    if ((s = revk_settings_find("target", NULL)) &&
@@ -349,7 +358,7 @@ load_legacy_settings(void)
    if ((s = revk_settings_find("led", NULL)) &&
        (v = revk_settings_text(s, 0, NULL)))
    {
-      led_state = atoi(v) ? 1 : 0;
+      led_state = parse_bool(v);
       free(v);
    }
    if ((s = revk_settings_find("timer", NULL)) &&
@@ -2907,7 +2916,7 @@ legacy_web_set_notify (httpd_req_t * req)
          char *v = jo_strdup (j);
          if (v)
          {
-            notify_enabled = atoi (v) ? 1 : 0;
+            notify_enabled = parse_bool (v);
             jo_t s = jo_object_alloc();
             jo_int (s, "notify", notify_enabled);
             revk_settings_store (s, NULL, 1);
@@ -3003,7 +3012,7 @@ legacy_web_set_led (httpd_req_t * req)
          char *v = jo_strdup (j);
          if (v)
          {
-            led_state = atoi (v) ? 1 : 0;
+            led_state = parse_bool (v);
             daikin_set_v_e (err, led, led_state);
             jo_t s = jo_object_alloc();
             jo_int (s, "led", led_state);


### PR DESCRIPTION
## Summary
- document finished tasks in new `DONE.md`
- clean up `AGENTS.md` and point to completed work
- accept `on`/`off` values in notify and LED endpoints

## Testing
- `make -C ESP help` *(fails: `/bin/csh` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866602bd79483308d1cdb5ba5319d6b