### PR TITLE
Improve notify and LED endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 
 - Extend the HTTP API according to `Tools/integration_plan.md`. Ensure stub
   endpoints behave like the official modules while integration work continues.
-- Add build and configuration support for **ESP32‑S2** and **ESP32‑S3** boards.
 
 ## Progress
 
@@ -22,6 +21,7 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 - ESP32-S3 build target available.
 - Timer, program and schedule timer settings now stored persistently.
 - Target, price and remote method updates apply immediately and are saved.
+- Notify and LED endpoints accept textual on/off parameters for compatibility.
 
 ## Pending hardware implementation
 

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2907,7 +2907,12 @@ legacy_web_set_notify (httpd_req_t * req)
          char *v = jo_strdup (j);
          if (v)
          {
-            notify_enabled = atoi (v) ? 1 : 0;
+            if (!strcasecmp (v, "on") || !strcasecmp (v, "true"))
+               notify_enabled = 1;
+            else if (!strcasecmp (v, "off") || !strcasecmp (v, "false"))
+               notify_enabled = 0;
+            else
+               notify_enabled = atoi (v) ? 1 : 0;
             jo_t s = jo_object_alloc();
             jo_int (s, "notify", notify_enabled);
             revk_settings_store (s, NULL, 1);
@@ -3003,7 +3008,12 @@ legacy_web_set_led (httpd_req_t * req)
          char *v = jo_strdup (j);
          if (v)
          {
-            led_state = atoi (v) ? 1 : 0;
+            if (!strcasecmp (v, "on") || !strcasecmp (v, "true"))
+               led_state = 1;
+            else if (!strcasecmp (v, "off") || !strcasecmp (v, "false"))
+               led_state = 0;
+            else
+               led_state = atoi (v) ? 1 : 0;
             daikin_set_v_e (err, led, led_state);
             jo_t s = jo_object_alloc();
             jo_int (s, "led", led_state);

--- a/done.md
+++ b/done.md
@@ -1,0 +1,3 @@
+# Completed Tasks
+
+- Build and configuration support for **ESP32-S2** and **ESP32-S3** boards.


### PR DESCRIPTION
## Summary
- allow textual `on`/`off` booleans for `/common/set_notify` and `/common/set_led`
- document completed board support in `done.md`
- record new API behaviour in `AGENTS.md`

## Testing
- `make -C ESP -n` *(fails: components/ESP32-RevK/buildsuffix missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866602bd79483308d1cdb5ba5319d6b