### PR TITLE
Enable LED and remote mode hardware hooks

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -8,4 +8,6 @@ The following tasks from `AGENTS.md` have been finished:
 - Timer, program and schedule timer values are saved across reboots.
 - Power history endpoints return placeholder data for compatibility.
 - Notification, region and LED settings persist and `/common/set_led` now supports "on"/"off" values.
+- `/common/set_notify` mirrors the setting to the physical LED.
+- `/common/set_remote_method` now toggles remote control mode.
 

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -2917,6 +2917,7 @@ legacy_web_set_notify (httpd_req_t * req)
          if (v)
          {
             notify_enabled = parse_bool (v);
+            daikin_set_v_e (err, led, notify_enabled); // mirror notify on LED
             jo_t s = jo_object_alloc();
             jo_int (s, "notify", notify_enabled);
             revk_settings_store (s, NULL, 1);
@@ -2957,11 +2958,13 @@ legacy_web_set_remote_method (httpd_req_t * req)
                strncpy(remote_method, "home only", sizeof(remote_method)-1);
             else
                strncpy(remote_method, v, sizeof(remote_method)-1);
-            remote_method[sizeof(remote_method) - 1] = 0;
-            jo_t s = jo_object_alloc();
-            jo_string (s, "remote_method", remote_method);
-            revk_settings_store (s, NULL, 1);
-            jo_free (&s);
+           remote_method[sizeof(remote_method) - 1] = 0;
+            daikin.remote = strcmp(remote_method, "home only") ? 1 : 0;
+            daikin.status_changed = 1;
+           jo_t s = jo_object_alloc();
+           jo_string (s, "remote_method", remote_method);
+           revk_settings_store (s, NULL, 1);
+           jo_free (&s);
          }
          free (v);
       }


### PR DESCRIPTION
## Summary
- route notify control to LED so changing notify toggles the unit LED
- link remote method changes to the `remote` flag
- document newly implemented tasks in DONE

## Testing
- `make -C ESP` *(fails: `/bin/csh` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866626abfb08330aea020a4e3aa3415