### PR TITLE
Implement program/schedule timer commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ appropriate S21 or CN_WIRED commands so Faikin mirrors the official Daikin
 modules.
 
 - `/aircon/get_timer` and `/aircon/set_timer`
-- `/aircon/get_program` and `/aircon/set_program`
-- `/aircon/get_scdltimer` and `/aircon/set_scdltimer`
+- `/aircon/get_program` and `/aircon/set_program` *(in progress)*
+- `/aircon/get_scdltimer` and `/aircon/set_scdltimer` *(in progress)*
 - `/aircon/get_price` and `/aircon/set_price`
 - `/common/get_notify` and `/common/set_notify`
 - `/common/get_remote_method` and `/common/set_remote_method`

--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,8 @@ The following tasks from `AGENTS.md` have been finished:
 - Added build and configuration support for **ESP32‑S2** and **ESP32‑S3** boards, including default UART pin mappings.
 - Target, price and remote method updates are stored persistently and apply immediately.
 - Timer, program and schedule timer values are saved across reboots.
+- Program and schedule timer endpoints now issue `DJ` and `DK` commands so the
+  air-con updates immediately.
 - Power history endpoints return placeholder data for compatibility.
 - Notification, region and LED settings persist and `/common/set_led` now supports "on"/"off" values.
 - `/common/set_notify` mirrors the setting to the physical LED.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -409,6 +409,42 @@ query_timer_state(void)
    daikin_s21_command('F', '3', 0, NULL);
 }
 
+static void
+send_program_command(const char *state)
+{
+   if (!uart_enabled() || !state || !*state)
+      return;
+   char payload[S21_PAYLOAD_LEN] = {0};
+   strncpy(payload, state, S21_PAYLOAD_LEN);
+   daikin_s21_command('D', 'J', S21_PAYLOAD_LEN, payload);
+}
+
+static void
+query_program_state(void)
+{
+   if (!uart_enabled())
+      return;
+   daikin_s21_command('F', 'J', 0, NULL);
+}
+
+static void
+send_scdltimer_command(const char *state)
+{
+   if (!uart_enabled() || !state || !*state)
+      return;
+   char payload[S21_PAYLOAD_LEN] = {0};
+   strncpy(payload, state, S21_PAYLOAD_LEN);
+   daikin_s21_command('D', 'K', S21_PAYLOAD_LEN, payload);
+}
+
+static void
+query_scdltimer_state(void)
+{
+   if (!uart_enabled())
+      return;
+   daikin_s21_command('F', 'K', 0, NULL);
+}
+
 static uint8_t
 proto_type (void)
 {
@@ -825,6 +861,26 @@ daikin_s21_response (uint8_t cmd, uint8_t cmd2, int len, uint8_t * payload)
          else if (s21.F6.bad && check_length (cmd, cmd2, len, 1, payload))
          {                     // Older units report powerful via G3
             report_bool (powerful, payload[3] & 0x02);
+         }
+         break;
+      case 'J':                // 'GJ' - weekly program state
+         if (check_length (cmd, cmd2, len, S21_PAYLOAD_LEN, payload))
+         {
+            char state[5];
+            memcpy (state, payload, 4);
+            state[4] = 0;
+            strncpy (program_state, state, sizeof (program_state) - 1);
+            program_state[sizeof (program_state) - 1] = 0;
+         }
+         break;
+      case 'K':                // 'GK' - schedule timer state
+         if (check_length (cmd, cmd2, len, S21_PAYLOAD_LEN, payload))
+         {
+            char state[5];
+            memcpy (state, payload, 4);
+            state[4] = 0;
+            strncpy (scdl_timer_state, state, sizeof (scdl_timer_state) - 1);
+            scdl_timer_state[sizeof (scdl_timer_state) - 1] = 0;
          }
          break;
       case '5':                // 'G5' - swing status
@@ -2860,6 +2916,7 @@ legacy_web_set_target (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_program (httpd_req_t * req)
 {
+   query_program_state();       // Poll current program from the unit
    jo_t j = legacy_ok ();
    if (*program_state)
       jo_string (j, "program", program_state);
@@ -2884,6 +2941,7 @@ legacy_web_set_program (httpd_req_t * req)
       jo_string (s, "program", program_state);
       revk_settings_store (s, NULL, 1);
       jo_free (&s);
+      send_program_command(program_state);
       jo_free (&j);
    }
    return legacy_simple_response (req, err);
@@ -2892,6 +2950,7 @@ legacy_web_set_program (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_scdltimer (httpd_req_t * req)
 {
+   query_scdltimer_state();     // Poll current schedule timer
    jo_t j = legacy_ok ();
    if (*scdl_timer_state)
       jo_string (j, "scdltimer", scdl_timer_state);
@@ -2916,6 +2975,7 @@ legacy_web_set_scdltimer (httpd_req_t * req)
       jo_string (s, "scdltimer", scdl_timer_state);
       revk_settings_store (s, NULL, 1);
       jo_free (&s);
+      send_scdltimer_command(scdl_timer_state);
       jo_free (&j);
    }
    return legacy_simple_response (req, err);


### PR DESCRIPTION
## Summary
- send DJ/DK commands when program and schedule timer are set
- poll current program and schedule timer values
- parse GJ/GK replies to update stored states
- update docs

## Testing
- `make -C ESP` *(fails: /bin/csh missing)*

------
https://chatgpt.com/codex/tasks/task_e_686675c675608330b228d8278209a144