### PR TITLE
Implement power meter polling

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -6,7 +6,7 @@ The following tasks from `AGENTS.md` have been finished:
 - Added build and configuration support for **ESP32‑S2** and **ESP32‑S3** boards, including default UART pin mappings.
 - Target, price and remote method updates are stored persistently and apply immediately.
 - Timer, program and schedule timer values are saved across reboots.
-- Power history endpoints return placeholder data for compatibility.
+- Power history endpoints now poll the power meter before returning data.
 - Notification, region and LED settings persist and `/common/set_led` now supports "on"/"off" values.
 - `/common/set_notify` mirrors the setting to the physical LED.
 - `/common/set_remote_method` now toggles remote control mode.

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -314,8 +314,16 @@ update_power_history(void)
       powermonth[last_power_month] += diff;
       last_power_day = tm.tm_yday;
       last_power_Wh = daikin.Wh;
-      save_power_history();
-   }
+     save_power_history();
+  }
+}
+
+static void
+query_power_meter(void)
+{
+   if (!uart_enabled())
+      return;
+   daikin_s21_command('F', 'M', 0, NULL);
 }
 
 static void
@@ -2751,6 +2759,7 @@ legacy_web_get_sensor_info (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_year_power (httpd_req_t * req)
 {
+   query_power_meter();          // Refresh Wh reading from the unit
    /*
     * The official modules return power totals for the current and previous
     * calendar years.  We only track a rolling 12‑month window so the current
@@ -2780,6 +2789,7 @@ legacy_web_get_year_power (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_week_power (httpd_req_t * req)
 {
+   query_power_meter();          // Refresh Wh reading from the unit
    update_power_history();
    jo_t j = legacy_ok();
    jo_string (j, "s_dayw", "0");


### PR DESCRIPTION
## Summary
- add `query_power_meter` helper for power endpoints
- refresh power readings in `/aircon/get_year_power` and `/aircon/get_week_power`
- note behaviour update in DONE.md

## Testing
- `make -C ESP help` *(fails: `Makefile:10: *** Please install /bin/csh or equivalent.  Stop.`)*

------
https://chatgpt.com/codex/tasks/task_e_68667c50d63483308670c0d09ccc9267