### PR TITLE
Implement get_notify hardware query

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -14,4 +14,6 @@ The following tasks from `AGENTS.md` have been finished:
   take effect on the unit.
 - Timer endpoints now parse the `timer`, `program` and `scdltimer`
   query parameters and forward them via S21 commands.
+- `/common/get_notify` polls the LED state so the returned value reflects the
+  current hardware setting.
 

--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -453,6 +453,14 @@ query_scdltimer_state(void)
    daikin_s21_command('F', '4', 0, NULL);
 }
 
+static void
+query_led_state(void)
+{
+   if (!uart_enabled())
+      return;
+   daikin_s21_command('F', '6', 0, NULL);
+}
+
 static uint8_t
 proto_type (void)
 {
@@ -3001,7 +3009,9 @@ legacy_web_set_scdltimer (httpd_req_t * req)
 static esp_err_t
 legacy_web_get_notify (httpd_req_t * req)
 {
-   jo_t j = legacy_ok ();          // Report stored notify state
+   query_led_state();
+   notify_enabled = daikin.led;
+   jo_t j = legacy_ok ();          // Report current notify state
    jo_int (&j, "notify", notify_enabled);
    return legacy_send (req, &j);
 }


### PR DESCRIPTION
## Summary
- poll LED state before responding to `/common/get_notify`
- document new behaviour in DONE.md

## Testing
- `make -n` *(fails: `/bin/csh` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866858b73e48330b9a979a191d55136