### PR TITLE
Add remote method and region hardware hooks

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -17,3 +17,7 @@ The following tasks from `AGENTS.md` have been finished:
 - `/common/get_notify` polls the LED state so the returned value reflects the
   current hardware setting.
 
+- `/common/set_remote_method` now forwards the policy via S21 `D8` commands.
+- `/common/get_remote_method` polls the current setting using `F8` before replying.
+- `/common/set_regioncode` sends the `D9` command so the region change takes effect on the unit.
+


### PR DESCRIPTION
## Summary
- hook remote method endpoints to new S21 `D8/F8` commands
- hook region code updates to S21 `D9`
- document completed tasks in DONE.md

## Testing
- `make` *(fails: components/ESP32-RevK/buildsuffix missing)*

------
https://chatgpt.com/codex/tasks/task_e_686687fa64588330820144548d14ffeb