### PR TITLE
Update docs to reflect completed HTTP hardware support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ avoid making unrelated changes. Changes should be submitted via pull request.
 
 ## Current Tasks
 
-The main outstanding work is implementing hardware support for the stubbed
-HTTP API endpoints.  See the list below.
+Most of the previously stubbed HTTP endpoints now forward their parameters to
+the air-con using S21 commands.  Only the pricing API remains purely
+configurational.
 
 For details of previously completed tasks see **DONE.md**.
 
@@ -18,14 +19,7 @@ work should update these handlers to translate incoming parameters into the
 appropriate S21 or CN_WIRED commands so Faikin mirrors the official Daikin
 modules.
 
-- `/aircon/get_timer` and `/aircon/set_timer`
-- `/aircon/get_program` and `/aircon/set_program`
-- `/aircon/get_scdltimer` and `/aircon/set_scdltimer`
 - `/aircon/get_price` and `/aircon/set_price`
-- `/common/get_notify` and `/common/set_notify`
-- `/common/get_remote_method` and `/common/set_remote_method`
-- `/common/set_regioncode`
-- `/aircon/get_year_power` and `/aircon/get_week_power`
 
 Implementing these will require referencing the Daikin protocol documents in
 `Manuals/S21.md` and extending the control logic in `ESP/main/Faikin.c`.

--- a/DONE.md
+++ b/DONE.md
@@ -20,4 +20,6 @@ The following tasks from `AGENTS.md` have been finished:
 - `/common/set_remote_method` now forwards the policy via S21 `D8` commands.
 - `/common/get_remote_method` polls the current setting using `F8` before replying.
 - `/common/set_regioncode` sends the `D9` command so the region change takes effect on the unit.
+- Remote method, notify, region and power history endpoints all query the unit
+  so responses reflect the actual hardware state.
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ continue to operate while hardware integration is completed.
 /aircon/get_week_power
 ```
 
-Hardware support is gradually being implemented.  The timer,
-program and schedule timer endpoints now send the relevant S21
-commands to the air conditioner.
+Hardware support now covers the majority of these handlers.  Timer,
+program and schedule timer requests are forwarded via S21 commands and
+the notify, remote method, region and power history APIs query the
+unit before replying.  Only the pricing endpoints remain local-only.
 
 ## Flashing code
 


### PR DESCRIPTION
## Summary
- document that most HTTP endpoints now talk to the unit
- keep only price API listed as pending in `AGENTS.md`
- clarify completed work in `DONE.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68668e17c6c88330b75bf7c0d4d768a3