### PR TITLE
Fix Makefile indentation

### DIFF
--- a/ESP/Makefile
+++ b/ESP/Makefile
@@ -54,12 +54,12 @@ s3:
 	@make
 
 s3n8:
-        components/ESP32-RevK/setbuildsuffix -S3-MINI-N8
-        @make
+	components/ESP32-RevK/setbuildsuffix -S3-MINI-N8
+	@make
 
 s2:
-        components/ESP32-RevK/setbuildsuffix -S2
-        @make
+	components/ESP32-RevK/setbuildsuffix -S2
+	@make
 
 pico:
 	components/ESP32-RevK/setbuildsuffix -S1-PICO


### PR DESCRIPTION
## Summary
- fix tab indentation for the s3n8 and s2 build targets

## Testing
- `make help` *(fails: /bin/csh missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866f3f94e108330bc6b5b8fb473faad