### PR TITLE
Fix settings.h make target

### DIFF
--- a/ESP/Makefile
+++ b/ESP/Makefile
@@ -36,6 +36,10 @@ issue:
 main/settings.h:     components/ESP32-RevK/revk_settings main/settings.def components/ESP32-RevK/settings.def
 	components/ESP32-RevK/revk_settings $^
 
+# Alias target for compatibility with build scripts
+settings.h: main/settings.h
+	@true
+
 components/ESP32-RevK/revk_settings: components/ESP32-RevK/revk_settings.c
 	make -C components/ESP32-RevK revk_settings
 


### PR DESCRIPTION
## Summary
- allow build scripts to call `make settings.h`

## Testing
- `make settings.h` *(fails: `/bin/csh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fc07b7a883309ad7057453e2866c