### PR TITLE
Fix CMake generation

### DIFF
--- a/ESP/main/CMakeLists.txt
+++ b/ESP/main/CMakeLists.txt
@@ -2,12 +2,14 @@ set(REVK_DIR ${CMAKE_CURRENT_LIST_DIR}/../components/ESP32-RevK)
 set(SETTINGS_DEF ${CMAKE_CURRENT_LIST_DIR}/settings.def)
 set(REVK_SETTINGS ${REVK_DIR}/revk_settings)
 
-add_custom_command(
-    OUTPUT settings.c settings.h
-    COMMAND ${REVK_SETTINGS} ${SETTINGS_DEF} -h settings.h -c settings.c
-    DEPENDS ${SETTINGS_DEF} ${REVK_DIR}/settings.def ${REVK_SETTINGS}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
+if(NOT CMAKE_SCRIPT_MODE_FILE)
+    add_custom_command(
+        OUTPUT settings.c settings.h
+        COMMAND ${REVK_SETTINGS} ${SETTINGS_DEF} -h settings.h -c settings.c
+        DEPENDS ${SETTINGS_DEF} ${REVK_DIR}/settings.def ${REVK_SETTINGS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    )
+endif()
 set_source_files_properties(settings.c PROPERTIES GENERATED TRUE)
 
 set(COMPONENT_SRCS "cn_wired_driver.c" "Faikin.c" "bleenv.c" "settings.c")


### PR DESCRIPTION
## Summary
- guard `add_custom_command` so it only runs during normal build

## Testing
- `make` *(fails: /bin/csh missing)*

------
https://chatgpt.com/codex/tasks/task_e_686708a612c8833098ef88ca9bb49aaf