### PR TITLE
Fix unmatched preprocessor directive

### DIFF
--- a/ESP/main/settings.def
+++ b/ESP/main/settings.def
@@ -2,7 +2,7 @@ bit	dump									// Dump protocol on MQTT for each message
 bit	debug				.live					// Debug (extra messages and list replies in one long message on MQTT)
 bit	debughex			.live					// Debug in hex
 bit	snoop									// Listen only (for debugging)
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+#ifdef CONFIG_IDF_TARGET_ESP32S2
 gpio    tx      26                                                     // Tx
 gpio    rx      27                                                     // Rx
 bit	livestatus			.live					// Send status messages in real time


### PR DESCRIPTION
## Summary
- fix `#elif` with no prior `#if` in `ESP/main/settings.def`

## Testing
- `python generate_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6867d267e0bc83309d326f1fcc022c24