### PR TITLE
Fix generate_settings failure

### DIFF
--- a/ESP/main/settings.def
+++ b/ESP/main/settings.def
@@ -2,10 +2,8 @@ bit	dump									// Dump protocol on MQTT for each message
 bit	debug				.live					// Debug (extra messages and list replies in one long message on MQTT)
 bit	debughex			.live					// Debug in hex
 bit	snoop									// Listen only (for debugging)
-bit     livestatus                      .live                                  /
-/ Send status messages in real time
-bit     fixstatus                                                              /
-/ Send status as fixed values not array
+bit     livestatus                      .live                                  // Send status messages in real time
+bit     fixstatus                                                              // Send status as fixed values not array
 bit	web.control	1							// Web based controls
 bit	web.settings	1							// Web based settings
 


### PR DESCRIPTION
## Summary
- fix split comments in `settings.def`

## Testing
- `python3 generate_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6867d6c0b55c8330a5e7b73d2b9bb08a