### PR TITLE
Fallback to bundled libpopt

### DIFF
--- a/generate_settings.py
+++ b/generate_settings.py
@@ -23,7 +23,13 @@ def build_tool():
         str(COMPONENT / "revk_settings.c"),
         "-g", "-Wall", "--std=gnu99", "-lpopt",
     ]
-    run(cmd, cwd=str(COMPONENT))
+    try:
+        run(cmd, cwd=str(COMPONENT))
+    except subprocess.CalledProcessError:
+        # Fall back to bundled static library if system libpopt is unavailable
+        popt_lib = ROOT / "ESP" / "libpopt.a"
+        cmd[-1] = str(popt_lib)
+        run(cmd, cwd=str(COMPONENT))
 
 
 def main():


### PR DESCRIPTION
## Summary
- make `generate_settings.py` fall back to `ESP/libpopt.a` when system libpopt is unavailable

## Testing
- `python generate_settings.py`
- `python -m py_compile generate_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_686810f9f4208330b56706f8a734a830