### PR TITLE
Add libpopt fallback to Makefile

### DIFF
--- a/ESP/Makefile
+++ b/ESP/Makefile
@@ -41,7 +41,9 @@ settings.h: main/settings.h
 	@true
 
 components/ESP32-RevK/revk_settings: components/ESP32-RevK/revk_settings.c
-	make -C components/ESP32-RevK revk_settings
+	@set -e; \
+	if gcc -O -o $@ $< -g -Wall --std=gnu99 -lpopt; then :; \
+	else gcc -O -o $@ $< -g -Wall --std=gnu99 libpopt.a; fi
 
 components/ESP32-RevK/idfmon: components/ESP32-RevK/idfmon.c
 	make -C components/ESP32-RevK idfmon


### PR DESCRIPTION
## Summary
- handle missing system libpopt when building via `make`

## Testing
- `python generate_settings.py -h` *(fails: popt.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686813b7185c8330a559f0e69aa9ca83