### PR TITLE
Add err.h shim for cross builds

### DIFF
--- a/ESP/include/err.h
+++ b/ESP/include/err.h
@@ -1,0 +1,42 @@
+#ifndef ERR_COMPAT_H
+#define ERR_COMPAT_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+static inline void warn(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+}
+
+static inline void warnx(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+}
+
+static inline void err(int eval, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+    exit(eval);
+}
+
+static inline void errx(int eval, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    va_end(ap);
+    exit(eval);
+}
+
+#endif /* ERR_COMPAT_H */

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ in your `PATH` so `build.bat` can compile the helper tools.  The helper tool
 `revk_settings` also depends on the [libpopt](https://github.com/rpm-software-management/popt)
 library.  Install the corresponding `popt` development package (e.g.
 `pacman -S mingw-w64-x86_64-popt` on MSYS2 or `libpopt-dev` on Debian
-derivatives) so `popt.h` is available during compilation.
+derivatives) so `popt.h` is available during compilation.  A minimal
+`err.h` shim is bundled under `ESP/include` so building does not require
+the BSD err library.
 
 Before invoking `idf.py` directly, run `python generate_settings.py` in the
 repository root (or `make settings.h` on platforms with `csh` installed).  This


### PR DESCRIPTION
## Summary
- ship a local `err.h` header to avoid missing dependency on some toolchains
- document the new header in the build instructions

## Testing
- `python generate_settings.py` *(fails: cannot find -lpopt)*

------
https://chatgpt.com/codex/tasks/task_e_68681d776a4483309b4ccad363213f2d