### PR TITLE
Fix missing revk_settings include

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -4,7 +4,7 @@
 static const char TAG[] = "Faikin";
 
 #include "revk.h"
-#include "revk_settings.c"
+#include "../components/ESP32-RevK/revk_settings.c"
 #include "esp_sleep.h"
 #include "esp_task_wdt.h"
 #include <driver/gpio.h>


### PR DESCRIPTION
## Summary
- adjust include path for `revk_settings.c`

## Testing
- `gcc -E ESP/main/Faikin.c -I ESP/components/ESP32-RevK -I ESP/components/ESP32-RevK/include` *(fails: `sdkconfig.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681f8f5e5083308d6681c8543a4820