### PR TITLE
Fix build by removing generator include

### DIFF
--- a/ESP/main/Faikin.c
+++ b/ESP/main/Faikin.c
@@ -4,7 +4,6 @@
 static const char TAG[] = "Faikin";
 
 #include "revk.h"
-#include "../components/ESP32-RevK/revk_settings.c"
 #include "esp_sleep.h"
 #include "esp_task_wdt.h"
 #include <driver/gpio.h>


### PR DESCRIPTION
## Summary
- remove inclusion of `revk_settings.c` in `Faikin.c`

This avoids macro conflicts when compiling firmware.

## Testing
- `python generate_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_686822e9e24083308141a675bcce9d26