### PR TITLE
Fix missing settings_lib.h include path

### DIFF
--- a/ESP/main/CMakeLists.txt
+++ b/ESP/main/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 idf_component_register(
     SRCS "cn_wired_driver.c" "Faikin.c" "bleenv.c" "settings.c"
-    INCLUDE_DIRS "." "../include"
+    INCLUDE_DIRS "." "../include" "../components/ESP32-RevK"
     REQUIRES ESP32-RevK
     EMBED_FILES "favicon.ico" "apple-touch-icon.png"
 )


### PR DESCRIPTION
## Summary
- add path to `ESP32-RevK` component so `settings_lib.h` resolves

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682e5641f0833081384b4355fa92ee