### PR TITLE
Fix missing settings header path

### DIFF
--- a/ESP/main/CMakeLists.txt
+++ b/ESP/main/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 idf_component_register(
     SRCS "cn_wired_driver.c" "Faikin.c" "bleenv.c" "settings.c"
-    INCLUDE_DIRS "." "../include"
+    INCLUDE_DIRS "." "../include" "${REVK_DIR}"
     REQUIRES ESP32-RevK
     EMBED_FILES "favicon.ico" "apple-touch-icon.png"
 )


### PR DESCRIPTION
## Summary
- include ESP32-RevK base directory in main component include paths
- run submodule and settings generation steps to ensure build files exist

## Testing
- `python3 generate_settings.py`
- *(build attempt failed: `idf.py` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682e5641f0833081384b4355fa92ee